### PR TITLE
Add PowerShell setup scripts for Windows

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,38 @@
+#!/usr/bin/env pwsh
+
+$ErrorActionPreference = 'Stop'
+
+# Get the directory where this script resides
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$ProjectRoot = Split-Path $ScriptDir -Parent
+
+function Log($msg) {
+    Write-Host $msg
+}
+
+function Run-Setup($scriptName, $scriptPath) {
+    Log "=== Running $scriptName ==="
+    & $scriptPath
+    if ($LASTEXITCODE -ne 0) {
+        Log "Error: $scriptName failed."
+        exit 1
+    }
+    Log "=== $scriptName completed successfully ==="
+}
+
+Set-Location $ProjectRoot
+
+Log "Starting full project setup..."
+Log ""
+
+Run-Setup "Backend Setup" "$ScriptDir/setup/setup-backend.ps1"
+Log ""
+Run-Setup "Frontend Setup" "$ScriptDir/setup/setup-frontend.ps1"
+Log ""
+
+Log ""
+Log "=== Setup Complete ==="
+Log "🚀 To start the development servers:"
+Log "1. In a new terminal, run: uv run python server/manage.py runserver_plus"
+Log "2. In another terminal, run: cd app && bun dev"
+Log "Then access the web app at: http://localhost:8000"

--- a/scripts/setup/setup-backend.ps1
+++ b/scripts/setup/setup-backend.ps1
@@ -1,0 +1,35 @@
+#!/usr/bin/env pwsh
+
+$ErrorActionPreference = 'Stop'
+
+function Log($msg) {
+    Write-Host $msg
+}
+
+Log "Setting up backend server..."
+
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Log "Installing uv..."
+    # Install uv using the official PowerShell script
+    iex (irm https://astral.sh/uv/install.ps1)
+    $envScript = Join-Path $HOME ".local/bin/env"
+    if (Test-Path $envScript) {
+        . $envScript
+    }
+} else {
+    Log "uv is already installed. Yay."
+}
+
+Log "Installing Python dependencies with uv..."
+uv sync
+
+Log "Running database migrations..."
+uv run python server/manage.py migrate
+
+Log ""
+Log "🚀 Backend setup completed successfully!"
+Log "To start the backend server, run: uv run python server/manage.py runserver_plus"
+Log ""
+Log "If you see the error 'uv : The term 'uv' is not recognized', then either"
+Log "run the command in a new terminal,"
+Log "or first execute the command: . $HOME/.local/bin/env"

--- a/scripts/setup/setup-frontend.ps1
+++ b/scripts/setup/setup-frontend.ps1
@@ -1,0 +1,36 @@
+#!/usr/bin/env pwsh
+
+$ErrorActionPreference = 'Stop'
+
+function Log($msg) {
+    Write-Host $msg
+}
+
+Log "Setting up frontend server..."
+
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+    Log "Installing Bun..."
+    # Install Bun using the official PowerShell script
+    iex (irm bun.sh/install.ps1)
+    $env:PATH = "$HOME/.bun/bin;" + $env:PATH
+} else {
+    Log "Bun is already installed. Yay."
+}
+
+Set-Location "app" -ErrorAction Stop
+
+Log "Installing npm packages..."
+bun install
+
+if (-not (Test-Path ".env")) {
+    Log "Creating .env file from sample..."
+    Copy-Item ".env.development.local.sample" ".env"
+}
+
+Log ""
+Log "🚀 Frontend setup completed successfully!"
+Log "To start the frontend server, run: bun dev"
+Log ""
+Log "If you see the error 'bun : The term 'bun' is not recognized', then either"
+Log "run the command in a new terminal,"
+Log 'or first execute the command: $env:PATH = "$HOME/.bun/bin;" + $env:PATH'


### PR DESCRIPTION
## Summary
- add Windows-compatible PowerShell versions of setup scripts
- provide PowerShell scripts for backend and frontend setup
- update Windows scripts to use the official PowerShell installers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test` *(fails: Missing script "test" in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845f7ff3bd48330a22777156576599a