### PR TITLE
Consolidate and streamline CLAUDE.md documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,142 +4,107 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-A Django + React web framework for rapid development of web applications. Features a micro-blogging app with public posts functionality.
+A Django + React web framework ("framework on top of frameworks") for rapid web app development. Ships with a micro-blogging app that supports public posts, file/media uploads, and audio transcription.
 
 ## Architecture
 
-### Backend (Django)
-- **Location**: `server/` directory
-- **Framework**: Django 5.2.5 with Django REST Framework
-- **Python**: 3.13+
-- **Apps**: Located in `server/apps/`
-  - `website` - Main website functionality
-  - `users` - User management
-  - `blogs` - Blogging features
-  - `uploads` - File upload handling
-  - `auth` - Authentication
-- **Config**: `server/config/settings.py` and `server/config/urls.py`
-- **Database**: SQLite for development (`server/db.sqlite3`), PostgreSQL for production
+Two cooperating tiers in one repo. In **development**, the backend (`runserver_plus` on `:8000`) and the frontend (`vite` via `bun dev`) run as separate processes; the app is accessed via the Vite dev server but the backend remains the source of truth for API routes. In **production**, the React app is built and copied into `server/static/app/`, and `server/apps/website/templates/website/dist/index.html` is served by Django for any non-API route via a final catch-all `re_path('', index)` in `server/config/urls.py`. That catch-all is significant: any path Django doesn't match earlier falls through to the SPA, so new backend routes must be registered **before** it.
 
-### Frontend (React + Vite)
-- **Location**: `app/` directory
-- **Framework**: React 19 with TypeScript, Vite bundler
-- **UI Components**: shadcn/ui with Radix UI primitives
-- **Styling**: Tailwind CSS v4
-- **Entry Point**: `app/src/main.tsx`
-- **Pages**: `app/src/pages/`
-- **Components**: `app/src/components/`
-- **API Client**: TanStack Query for data fetching
+### Backend (`server/`)
+- Django 5.2.5 + DRF, Python 3.13+, managed by `uv`.
+- Django apps live in `server/apps/`: `website`, `users`, `blogs`, `uploads`, `auth`.
+- The `manage.py` is at `server/manage.py`, but **Python commands are run from the project root** (e.g. `uv run python server/manage.py …`).
+- Routing is centralized in `server/config/urls.py` — apps do not currently define their own `urls.py`; views are imported directly and a single DRF `DefaultRouter` registers `PostViewSet` at `/api/posts/`.
+- Settings split: `server/config/settings.py` (base/dev) and `server/config/settings_production.py`. Env loaded via `environs` from `server/.env` (a missing `.env` is auto-created on first run — see `check_and_create_env_file`).
+- DB: SQLite in dev (`server/db.sqlite3`), Postgres in prod. WhiteNoise serves static; media can be local or Cloudflare R2 (S3-compatible via `django-storages`/`boto3`).
+- Test layout is **inconsistent across apps**: `blogs/` uses a `tests/` package (`test_models.py`, `test_views.py`); `website/`, `users/`, `auth/` use a single `tests.py`. Be sure to mirror the existing structure for the app you're modifying.
 
-## Development Commands
+### Frontend (`app/`)
+- React 19 + TypeScript + Vite, managed by `bun`. UI is shadcn/ui on top of Radix; styling is Tailwind v4 (via `@tailwindcss/vite`). Data fetching is TanStack Query; routing is `react-router` v7.
+- Path alias `@/` → `app/src/` (configured in `vite.config.ts` and `tsconfig.json`).
+- Vite has a `base` switch: in production builds, `base` is set to `/static/app/` so the built assets resolve under Django's static URL. Don't hardcode asset paths.
+- `lovable-tagger` runs only in dev mode; the production build script (`admin/prod/build-prod.sh`) strips Lovable-related script/meta tags from the served `index.html`.
+- Tests: Vitest + React Testing Library (`app/src/__tests__/`) for unit/component, Playwright (`app/e2e/`) for end-to-end.
 
-### Backend Commands
+## Commands
+
+`just` is the canonical task runner. Run `just --list` to see everything. Common recipes live in `justfile` + `admin/justfiles/{dev,django,fly.io}.just`.
+
+### Backend (run from project root)
 ```bash
-# Start Django development server
-uv run python server/manage.py runserver_plus
-# Or using justfile
-just dev
-
-# Database migrations
-uv run python server/manage.py makemigrations
-uv run python server/manage.py migrate
-# Or using justfile
-just makemigrations
-just migrate
-
-# Django shell
-uv run python server/manage.py shell_plus
-# Or using justfile
-just shell
-
-# Run backend tests
-uv run python server/manage.py test
-# Or using justfile
-just test
-
-# Create superuser
-uv run python server/manage.py createsuperuser
-# Or using justfile
+just dev                  # tmux session: backend + frontend + 2 CLIs (NOT just `runserver`)
+just runserver            # uv run python server/manage.py runserver_plus
+just migrate              # apply migrations
+just makemigrations       # generate migrations
+just shell                # shell_plus (django-extensions)
+just test                 # full Django test suite
 just createsuperuser
+just collectstatic
+just manage-py <args>     # generic passthrough to manage.py
 
-# Python linting/formatting
-black server/
-isort server/
-# Or use ruff (configured in pyproject.toml)
-ruff check server/
-ruff format server/
+# Run a single Django test (dotted path under `server/apps/`)
+uv run python server/manage.py test apps.blogs.tests.test_models
+uv run python server/manage.py test apps.blogs.tests.test_models.PostModelTests.test_some_case
+
+# Python lint/format
+ruff check server/ && ruff format server/
+black server/ && isort server/    # also configured; black uses skip-string-normalization
 ```
 
-### Frontend Commands
+### Frontend (run from `app/`)
 ```bash
-# Navigate to frontend directory first
-cd app
-
-# Start development server
-bun dev
-
-# Build for production
-bun run build
-
-# Build for development
-bun run build:dev
-
-# Run linting
-bun run lint
-
-# Format code
-bun run format
-
-# Check formatting
-bun run format:check
-
-# Run tests
-bun test
+bun dev                   # Vite dev server
+bun run build             # production build
+bun run build:dev         # dev-mode build (keeps lovable-tagger)
+bun run lint              # ESLint
+bun run format            # biome format --write
+bun run check             # biome check
+bun test                  # Vitest (single run)
 bun run test:watch
 bun run test:coverage
+bun run test:e2e          # Playwright (also :ui, :headed, :debug, :report)
+
+# Run a single Vitest file or test by name
+bun test src/__tests__/components/Foo.test.tsx
+bun test -t "renders the header"
 ```
 
-### Project-Level Commands
+### Project root
 ```bash
-# Format JavaScript/TypeScript files (using Biome)
-npx @biomejs/biome format --write .
-npx @biomejs/biome check .
-
-# Start both servers using tmux
-./admin/dev/start-tmux-session.sh
-
-# Build for production
-./admin/prod/build-prod.sh
+npx @biomejs/biome check .          # Biome at repo root (uses biome.json)
+./admin/prod/build-prod.sh           # full prod build: migrate, collectstatic, vite build, copy into server/
+./admin/setup/setup-all.sh           # first-time local setup
 ```
 
-## Code Style and Conventions
+### Deploy (Fly.io)
+SQLite (single-host) and Postgres (HA) configs are both supported.
+```bash
+just fly-launch-app <name>           # alias for fly-launch-app-sqlite
+just fly-launch-app-postgres <name>
+just fly-launch-app-ha <name>        # postgres + clone db machines for HA
+just fly-deploy-app-sqlite <name>
+just fly-deploy-app-postgres <name>
+```
+Fly configs are in `admin/configs/fly-{sqlite,postgres}.toml`. Note that scripts use `gsed` on macOS — install via `brew install gsed` or `admin/setup/setup-mac.sh`.
 
-### Python/Django
-- Use Black for formatting (configured to preserve string quotes)
-- Use isort for import sorting
-- Ruff is configured for linting with Django-specific rules
-- Follow Google docstring convention
-- Line length: 99 characters
+## Conventions
 
-### TypeScript/React
-- Use Biome for formatting (`bun run format`) and code checking (`bun run check`)
-- Use ESLint for linting (`bun run lint`)
-- Tab indentation with 2 spaces width
-- Single quotes for strings
-- Trailing commas in ES5 style
-- Components use functional components with TypeScript
-- Use shadcn/ui component patterns
+### Python
+- Ruff (`pyproject.toml`) selects `E,F,I,DJ,D,B,N,UP`. Migrations are excluded. Line length 99. Target `py313`.
+- Black config has `skip-string-normalization = true` — **don't auto-flip single↔double quotes**. Ruff's formatter mirrors this with `quote-style = "preserve"`.
+- Docstring convention: Google style (enforced by `pydocstyle` via Ruff).
+- `isort` profile = black.
+- Pyright includes `admin` + `server` only (frontend excluded from Python type-checking).
 
-### Testing
-- Backend: Django's built-in test framework
-- Frontend: Vitest with React Testing Library
-- Run tests before committing significant changes
+### TypeScript / React
+- Biome is the formatter and primary checker; ESLint is also wired up. **Tabs**, 2-wide; single quotes; trailing commas ES5; semicolons as needed; max line 100.
+- `biome.json` ignores `dist/`, `tsconfig*.json`, `vite.config.ts`, `.vscode/` — don't fight the tool by editing those for style.
+- Functional components only; use shadcn/ui patterns; place reusable logic in `app/src/hooks/`.
 
-## Important Notes
+## Notes That Will Save You Time
 
-- Package managers: `uv` for Python, `bun` for JavaScript
-- Environment files: `.env` files in both `server/` and `app/` directories
-- Static files are served by WhiteNoise in production
-- CORS is configured for local development
-- The project supports deployment to Fly.io with both SQLite and PostgreSQL configurations
-- File uploads can use local storage or Cloudflare R2 (S3-compatible)
+- **Run all Python commands from the project root**, not from `server/`. The `.env` discovery logic checks for a `server/` child dir to decide where to look (`server/.env` vs `.env`), so cwd matters.
+- New backend URL patterns must be added in `server/config/urls.py` **before** the trailing `re_path('', index)` catch-all, or they'll be swallowed by the SPA.
+- `just dev` launches a tmux session with four panes (backend, frontend, two CLI shells) — it is **not** just an alias for `runserver`. If tmux isn't installed or you only want one server, use `just runserver` and `cd app && bun dev` directly.
+- The production build script writes `server/static/app/` and `server/apps/website/templates/website/dist/index.html`; both are derived artifacts and shouldn't be hand-edited.
+- Package managers are pinned by role: `uv` for Python (`uv.lock`), `bun` for the frontend (`app/bun.lock`). The root `package.json` exists only to pull in Biome via `npx`.


### PR DESCRIPTION
## Summary

Restructured and condensed `CLAUDE.md` to be more concise and actionable while preserving all essential guidance. The updated document emphasizes the dual-tier architecture, clarifies command invocation patterns, and highlights critical conventions that prevent common mistakes.

## Key Changes

- **Architecture section**: Replaced verbose subsections with a unified explanation of how dev and production modes differ, emphasizing the catch-all SPA route and the importance of registering new backend routes before it
- **Backend/Frontend descriptions**: Consolidated into bullet-point summaries with key technical details (frameworks, versions, package managers, storage options, test structure inconsistencies)
- **Commands reorganization**: 
  - Grouped by context (Backend, Frontend, Project root, Deploy)
  - Moved from verbose bash blocks to concise command listings with brief descriptions
  - Highlighted `just` as the canonical task runner with a reference to `just --list`
  - Included single-test invocation examples for both Django and Vitest
- **Conventions section**: Extracted and clarified Python and TypeScript/React style rules with specific tool configurations (Ruff, Black, Biome)
- **New "Notes That Will Save You Time" section**: Elevated critical gotchas:
  - Running Python commands from project root (not `server/`)
  - URL pattern registration order (before the catch-all)
  - `just dev` behavior (tmux session, not just an alias)
  - Derived artifacts in production builds
  - Package manager pinning by role

## Notable Details

- Removed redundant command examples and verbose explanations
- Preserved all technical accuracy (Django 5.2.5, React 19, Python 3.13+, etc.)
- Clarified test structure inconsistency across Django apps (blogs/ uses tests/ package; others use tests.py)
- Emphasized environment file discovery logic and its dependency on working directory
- Maintained all deployment guidance (Fly.io SQLite/Postgres/HA configs, gsed on macOS)

https://claude.ai/code/session_01GnhNN3oLYRcjmm5iw4yRi7